### PR TITLE
The build workflows are now sync'ed to the same commit.

### DIFF
--- a/.github/workflows/build-all.yaml
+++ b/.github/workflows/build-all.yaml
@@ -55,6 +55,12 @@ jobs:
           echo "APIO_COMMIT=${apio_commit}" >> "$GITHUB_ENV"
 
 
+      - name: Pip install apio.
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e apio-repo
+
+
       - name: Extract apio version
         run: |
           apio_version="$(pip show apio | grep Version: | cut -d ' ' -f2)"

--- a/.github/workflows/build-all.yaml
+++ b/.github/workflows/build-all.yaml
@@ -46,12 +46,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{env.APIO_REPO}}
-          ref: ${{env.APIO_COMMIT}}
+          ref: develop
           path: apio-repo
           fetch-depth: 0
 
 
-      - name: Get apio commit SHA
+      - name: Get apio commit
         id: get_apio_commit
         run: |
           apio_commit=$(git -C apio-repo rev-parse HEAD)

--- a/.github/workflows/build-all.yaml
+++ b/.github/workflows/build-all.yaml
@@ -26,7 +26,9 @@ jobs:
       apio_version: ${{ steps.get_apio_version.outputs.apio_version }}
 
     env:
-      DATE_TAG: date-tag-tbd
+      DATE_TAG: value-tbd
+      APIO_COMMIT: value-tbd
+      APIO_CERSION: value-tbd
 
     steps:
 
@@ -99,7 +101,7 @@ jobs:
 
       steps:
 
-        - name: Setup env.
+        - name: Set up env.
           run: |
             echo "DATE_TAG=${{ needs.prepare.outputs.date_tag }}" >> "$GITHUB_ENV"
             echo "APIO_COMMIT=${{ needs.prepare.outputs.apio_commit }}" >> "$GITHUB_ENV"
@@ -124,10 +126,9 @@ jobs:
             body: |
               This is an automated build of the Apio's repo `develop` branch.
 
-              | ------------ | --------------------- |
-              | Date tag     | ${{env.DATE_TAG}}     |
-              | Apio version | ${{env.APIO_VERSION}} |
-              | Apio commit  | ${{env.APIO_COMMIT}}  |
+              * `DATE_TAG`: ${{env.DATE_TAG}}
+              * `APIO_VERSION`: ${{env.APIO_VERSION}}
+              * `APIO_COMMIT`: ${{env.APIO_COMMIT}}
 
               Resources
               * [installation instructions](https://github.com/${{github.repository}}).

--- a/.github/workflows/build-all.yaml
+++ b/.github/workflows/build-all.yaml
@@ -86,7 +86,7 @@ jobs:
   # ---------------
 
   publish:
-      needs: [build-darwin, build-linux, build-windows]
+      needs: [prepare, build-darwin, build-linux, build-windows]
 
       runs-on: ubuntu-latest
 
@@ -97,9 +97,9 @@ jobs:
 
         - name: Init env.
           run: |
-            echo "date_tag=${{ needs.prepare.outputs.date_tag }}" >> "$GITHUB_ENV"
-            echo "apio_commit=${{ needs.prepare.outputs.apio_version }}" >> "$GITHUB_ENV"
-            echo "apio_version=${{ needs.prepare.outputs.apio_version }}" >> "$GITHUB_ENV"
+            echo "DATE_TAG=${{ needs.prepare.outputs.date_tag }}" >> "$GITHUB_ENV"
+            echo "APIO_COMMIT=${{ needs.prepare.outputs.apio_version }}" >> "$GITHUB_ENV"
+            echo "APIO_VERSION=${{ needs.prepare.outputs.apio_version }}" >> "$GITHUB_ENV"
 
         - name: Download the build artifacts
           uses: actions/download-artifact@v4

--- a/.github/workflows/build-all.yaml
+++ b/.github/workflows/build-all.yaml
@@ -23,9 +23,9 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      apio_tag: ${{ steps.get_date_tag.outputs.apio_tag }}
-      apio_commit: ${{ steps.get_apio_commit.outputs.apio_commit }}
-      apio_version: ${{ steps.get_apio_version.outputs.apio_version }}
+      apio_tag: ${{steps.get_date_tag.outputs.apio_tag}}
+      apio_commit: ${{steps.get_apio_commit.outputs.apio_commit}}
+      apio_version: ${{steps.get_apio_version.outputs.apio_version}}
 
     env:
       APIO_TAG: value-tbd
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{env.APIO_REPO}}
-          ref: develop
+          ref: ${{env.APIO_COMMIT}}
           path: apio-repo
           fetch-depth: 0
 
@@ -79,9 +79,10 @@ jobs:
     needs: prepare
     uses: ./.github/workflows/build-darwin-arm64.yml
     with:
-      apio_tag: ${{ needs.prepare.outputs.apio_tag }}
-      apio_commit: ${{ needs.prepare.outputs.apio_commit }}
-      apio_version: ${{ needs.prepare.outputs.apio_version }}
+      apio_repo: ${{needs.prepare.outputs.apio_repo}}
+      apio_tag: ${{needs.prepare.outputs.apio_tag}}
+      apio_commit: ${{needs.prepare.outputs.apio_commit}}
+      apio_version: ${{needs.prepare.outputs.apio_version}}
     secrets: inherit
 
 
@@ -89,9 +90,10 @@ jobs:
     needs: prepare
     uses: ./.github/workflows/build-linux-x86-64.yml
     with:
-      apio_tag: ${{ needs.prepare.outputs.apio_tag }}
-      apio_commit: ${{ needs.prepare.outputs.apio_commit }}
-      apio_version: ${{ needs.prepare.outputs.apio_version }}
+      apio_repo: ${{needs.prepare.outputs.apio_repo}}
+      apio_tag: ${{needs.prepare.outputs.apio_tag}}
+      apio_commit: ${{needs.prepare.outputs.apio_commit}}
+      apio_version: ${{needs.prepare.outputs.apio_version}}
     secrets: inherit
 
 
@@ -99,9 +101,10 @@ jobs:
     needs: prepare
     uses: ./.github/workflows/build-windows-amd64.yml
     with:
-      apio_tag: ${{ needs.prepare.outputs.apio_tag }}
-      apio_commit: ${{ needs.prepare.outputs.apio_commit }}
-      apio_version: ${{ needs.prepare.outputs.apio_version }}
+      apio_repo: ${{needs.prepare.outputs.apio_repo}}
+      apio_tag: ${{needs.prepare.outputs.apio_tag}}
+      apio_commit: ${{needs.prepare.outputs.apio_commit}}
+      apio_version: ${{needs.prepare.outputs.apio_version}}
     secrets: inherit
 
 
@@ -121,9 +124,9 @@ jobs:
 
         - name: Set up env
           run: |
-            echo "APIO_TAG=${{ needs.prepare.outputs.apio_tag }}" >> "$GITHUB_ENV"
-            echo "APIO_COMMIT=${{ needs.prepare.outputs.apio_commit }}" >> "$GITHUB_ENV"
-            echo "APIO_VERSION=${{ needs.prepare.outputs.apio_version }}" >> "$GITHUB_ENV"
+            echo "APIO_TAG=${{needs.prepare.outputs.apio_tag}}" >> "$GITHUB_ENV"
+            echo "APIO_COMMIT=${{needs.prepare.outputs.apio_commit}}" >> "$GITHUB_ENV"
+            echo "APIO_VERSION=${{needs.prepare.outputs.apio_version}}" >> "$GITHUB_ENV"
 
         - name: Download the build artifacts
           uses: actions/download-artifact@v4

--- a/.github/workflows/build-all.yaml
+++ b/.github/workflows/build-all.yaml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
 
+# --------------
 
   prepare:
     # needs: [build-darwin, build-linux, build-windows]
@@ -21,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      date_tag: ${{ steps.get_date_tag.outputs.get_tag }}
+      date_tag: ${{ steps.get_date_tag.outputs.date_tag }}
       apio_commit: ${{ steps.get_apio_commit.outputs.apio_commit }}
       apio_version: ${{ steps.get_apio_version.outputs.apio_version }}
 
@@ -35,7 +36,6 @@ jobs:
         run: |
           date_tag="$(date +'%Y-%m-%d')"
           echo "${date_tag}"
-          # echo "DATE_TAG=${date_tag}" >> "$GITHUB_ENV"
           echo "date_tag=${date_tag}" >> "$GITHUB_OUTPUT"
 
 
@@ -53,7 +53,6 @@ jobs:
         run: |
           apio_commit=$(git -C apio-repo rev-parse HEAD)
           echo "${apio_commit}"
-          # echo "APIO_COMMIT=${apio_commit}" >> "$GITHUB_ENV"
           echo "apio_commit=${apio_commit}" >> "$GITHUB_OUTPUT"
 
 
@@ -68,11 +67,9 @@ jobs:
         run: |
           apio_version="$(pip show apio | grep Version: | cut -d ' ' -f2)"
           echo ${apio_version}
-          # echo "APIO_VERSION=${apio_version}" >> $GITHUB_ENV
           echo "apio_version=${apio_version}" >> $GITHUB_OUTPUT
 
-  # ----------------
-
+  # --------------
 
   build-darwin:
     needs: prepare
@@ -85,7 +82,6 @@ jobs:
   build-windows:
     needs: prepare
     uses: ./.github/workflows/build-windows-amd64.yml
-
 
   # ---------------
 

--- a/.github/workflows/build-all.yaml
+++ b/.github/workflows/build-all.yaml
@@ -49,7 +49,7 @@ jobs:
           path: apio-repo
 
 
-      - name: Get apio commit SHA.
+      - name: Get apio commit SHA
         id: get_apio_commit
         run: |
           apio_commit=$(git -C apio-repo rev-parse HEAD)
@@ -57,7 +57,7 @@ jobs:
           echo "apio_commit=${apio_commit}" >> "$GITHUB_OUTPUT"
 
 
-      - name: Pip install apio.
+      - name: Pip install apio
         run: |
           python -m pip install --upgrade pip
           pip install -e apio-repo
@@ -101,7 +101,7 @@ jobs:
 
       steps:
 
-        - name: Set up env.
+        - name: Set up env
           run: |
             echo "DATE_TAG=${{ needs.prepare.outputs.date_tag }}" >> "$GITHUB_ENV"
             echo "APIO_COMMIT=${{ needs.prepare.outputs.apio_commit }}" >> "$GITHUB_ENV"

--- a/.github/workflows/build-all.yaml
+++ b/.github/workflows/build-all.yaml
@@ -97,7 +97,7 @@ jobs:
         - name: Setup env.
           run: |
             echo "DATE_TAG=${{ needs.prepare.outputs.date_tag }}" >> "$GITHUB_ENV"
-            echo "APIO_COMMIT=${{ needs.prepare.outputs.apio_version }}" >> "$GITHUB_ENV"
+            echo "APIO_COMMIT=${{ needs.prepare.outputs.apio_commit }}" >> "$GITHUB_ENV"
             echo "APIO_VERSION=${{ needs.prepare.outputs.apio_version }}" >> "$GITHUB_ENV"
 
         - name: Download the build artifacts

--- a/.github/workflows/build-all.yaml
+++ b/.github/workflows/build-all.yaml
@@ -73,6 +73,11 @@ jobs:
   build-darwin_arm64:
     needs: prepare
     uses: ./.github/workflows/build-darwin-arm64.yml
+    with:
+      date_tag: ${{ needs.prepare.outputs.date_tag }}
+      apio_commit: ${{ needs.prepare.outputs.apio_commit }}
+      apio_version: ${{ needs.prepare.outputs.apio_version }}
+    secrets: inherit
 
   build-linux-x86-64:
     needs: prepare
@@ -117,16 +122,16 @@ jobs:
             tag_name: ${{env.DATE_TAG}}
             name: ${{env.DATE_TAG}}
             body: |
-              This is an automated build of the Apio's develop branch.
+              This is an automated build of the Apio's repo `develop` branch.
 
               | ------------ | --------------------- |
               | Date tag     | ${{env.DATE_TAG}}     |
               | Apio version | ${{env.APIO_VERSION}} |
               | Apio commit  | ${{env.APIO_COMMIT}}  |
 
-              For installation instruction see (https://github.com/${{github.repository}}).
-
-              For the official releases see (https://github.com/FPGAwars/apio/releases).
+              Resources
+              * [installation instructions](https://github.com/${{github.repository}}).
+              * [Official Apio releases](https://github.com/FPGAwars/apio/releases).
 
             files: |
               # Darwin

--- a/.github/workflows/build-all.yaml
+++ b/.github/workflows/build-all.yaml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
+      apio_repo: ${{env.APIO_REPO}}
       apio_tag: ${{steps.get_date_tag.outputs.apio_tag}}
       apio_commit: ${{steps.get_apio_commit.outputs.apio_commit}}
       apio_version: ${{steps.get_apio_version.outputs.apio_version}}

--- a/.github/workflows/build-all.yaml
+++ b/.github/workflows/build-all.yaml
@@ -38,7 +38,21 @@ jobs:
           echo "${date_tag}"
           echo "DATE_TAG=${date_tag}" >> "$GITHUB_ENV"
 
-      - name: Download artifacts
+      - name: Checkout the apio repo
+        uses: actions/checkout@v4
+        with:
+          repository: FPGAwars/apio
+          # repository: zapta/apio-dev
+          ref: develop
+          path: apio-repo
+
+      - name: Get apio commit SHA.
+        run: |
+          cd apio-repo
+          apio_commit_hash=$(git rev-parse HEAD)
+          echo "Apio's commit: ${apio_commit_hash}}"
+
+      - name: Download the build artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts

--- a/.github/workflows/build-all.yaml
+++ b/.github/workflows/build-all.yaml
@@ -21,12 +21,12 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      date_tag: ${{ steps.get_date_tag.outputs.date_tag }}
+      apio_tag: ${{ steps.get_date_tag.outputs.apio_tag }}
       apio_commit: ${{ steps.get_apio_commit.outputs.apio_commit }}
       apio_version: ${{ steps.get_apio_version.outputs.apio_version }}
 
     env:
-      DATE_TAG: value-tbd
+      APIO_TAG: value-tbd
       APIO_COMMIT: value-tbd
       APIO_VERSION: value-tbd
 
@@ -35,9 +35,9 @@ jobs:
       - name: Get date tag
         id: get_date_tag
         run: |
-          date_tag="$(date +'%Y-%m-%d')"
-          echo "${date_tag}"
-          echo "date_tag=${date_tag}" >> "$GITHUB_OUTPUT"
+          apio_tag="$(date +'%Y-%m-%d')"
+          echo "${apio_tag}"
+          echo "apio_tag=${apio_tag}" >> "$GITHUB_OUTPUT"
 
 
       - name: Checkout the apio repo
@@ -77,7 +77,7 @@ jobs:
     needs: prepare
     uses: ./.github/workflows/build-darwin-arm64.yml
     with:
-      date_tag: ${{ needs.prepare.outputs.date_tag }}
+      apio_tag: ${{ needs.prepare.outputs.apio_tag }}
       apio_commit: ${{ needs.prepare.outputs.apio_commit }}
       apio_version: ${{ needs.prepare.outputs.apio_version }}
     secrets: inherit
@@ -87,7 +87,7 @@ jobs:
     needs: prepare
     uses: ./.github/workflows/build-linux-x86-64.yml
     with:
-      date_tag: ${{ needs.prepare.outputs.date_tag }}
+      apio_tag: ${{ needs.prepare.outputs.apio_tag }}
       apio_commit: ${{ needs.prepare.outputs.apio_commit }}
       apio_version: ${{ needs.prepare.outputs.apio_version }}
     secrets: inherit
@@ -97,7 +97,7 @@ jobs:
     needs: prepare
     uses: ./.github/workflows/build-windows-amd64.yml
     with:
-      date_tag: ${{ needs.prepare.outputs.date_tag }}
+      apio_tag: ${{ needs.prepare.outputs.apio_tag }}
       apio_commit: ${{ needs.prepare.outputs.apio_commit }}
       apio_version: ${{ needs.prepare.outputs.apio_version }}
     secrets: inherit
@@ -111,13 +111,15 @@ jobs:
       runs-on: ubuntu-latest
 
       env:
-        DATE_TAG: date-tag-tbd
+        APIO_TAG: value-tbd
+        APIO_COMMIT: value-tbd
+        APIO_VERSION: value-tbd
 
       steps:
 
         - name: Set up env
           run: |
-            echo "DATE_TAG=${{ needs.prepare.outputs.date_tag }}" >> "$GITHUB_ENV"
+            echo "APIO_TAG=${{ needs.prepare.outputs.apio_tag }}" >> "$GITHUB_ENV"
             echo "APIO_COMMIT=${{ needs.prepare.outputs.apio_commit }}" >> "$GITHUB_ENV"
             echo "APIO_VERSION=${{ needs.prepare.outputs.apio_version }}" >> "$GITHUB_ENV"
 
@@ -135,13 +137,13 @@ jobs:
         - name: Create GitHub release
           uses: softprops/action-gh-release@v2
           with:
-            tag_name: ${{env.DATE_TAG}}
-            name: ${{env.DATE_TAG}}
+            tag_name: ${{env.APIO_TAG}}
+            name: ${{env.APIO_TAG}}
             body: |
               This is an automated build of the Apio's repo `develop` branch.
 
               ```
-                  DATE_TAG:      ${{env.DATE_TAG}}
+                  APIO_TAG:      ${{env.APIO_TAG}}
                   APIO_VERSION:  ${{env.APIO_VERSION}}
                   APIO_COMMIT:   ${{env.APIO_COMMIT}}
               ```

--- a/.github/workflows/build-all.yaml
+++ b/.github/workflows/build-all.yaml
@@ -149,10 +149,10 @@ jobs:
               This is an automated build of the Apio's repo `develop` branch.
 
               ```
-                  APIO_REPO:     [${{env.APIO_REPO}}]
-                  APIO_TAG:      [${{env.APIO_TAG}}]
-                  APIO_VERSION:  [${{env.APIO_VERSION}}]
-                  APIO_COMMIT:   [${{env.APIO_COMMIT}}]
+                  APIO_REPO:     ${{env.APIO_REPO}}
+                  APIO_TAG:      ${{env.APIO_TAG}}
+                  APIO_VERSION:  ${{env.APIO_VERSION}}
+                  APIO_COMMIT:   ${{env.APIO_COMMIT}}
               ```
 
               Resources
@@ -162,8 +162,8 @@ jobs:
 
             files: |
               # Darwin
-              artifacts/apio-darwin-arm64-bundle/**
               artifacts/apio-darwin-arm64-installer/**
+              artifacts/apio-darwin-arm64-bundle/**
 
               # Linux
               artifacts/apio-linux-x86-64-bundle/**

--- a/.github/workflows/build-all.yaml
+++ b/.github/workflows/build-all.yaml
@@ -28,7 +28,7 @@ jobs:
     env:
       DATE_TAG: value-tbd
       APIO_COMMIT: value-tbd
-      APIO_CERSION: value-tbd
+      APIO_VERSION: value-tbd
 
     steps:
 

--- a/.github/workflows/build-all.yaml
+++ b/.github/workflows/build-all.yaml
@@ -38,6 +38,7 @@ jobs:
           echo "${date_tag}"
           echo "DATE_TAG=${date_tag}" >> "$GITHUB_ENV"
 
+
       - name: Checkout the apio repo
         uses: actions/checkout@v4
         with:
@@ -46,20 +47,31 @@ jobs:
           ref: develop
           path: apio-repo
 
+
       - name: Get apio commit SHA.
         run: |
-          cd apio-repo
-          apio_commit_hash=$(git rev-parse HEAD)
-          echo "Apio's commit: ${apio_commit_hash}}"
+          apio_commit=$(git -C apio-repo rev-parse HEAD)
+          echo "${apio_commit}"
+          echo "APIO_COMMIT=${apio_commit}" >> "$GITHUB_ENV"
+
+
+      - name: Extract apio version
+        run: |
+          apio_version="$(pip show apio | grep Version: | cut -d ' ' -f2)"
+          echo ${apio_version}
+          echo "APIO_VERSION=${apio_version}" >> $GITHUB_ENV
+
 
       - name: Download the build artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts
 
+
       - name: List files
         run: |
           find artifacts
+
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
@@ -67,7 +79,10 @@ jobs:
           tag_name: ${{env.DATE_TAG}}
           name: ${{env.DATE_TAG}}
           body: |
-            This is the automated release of Apio's development branch for ${{env.DATE_TAG}} 
+            This is an automated build of the Apio's develop branch.
+            - Date tag:       [${{env.DATE_TAG}}]
+            - Apio version:   [${{env.APIO_VERSION}}]
+            - Apio commit:    [${{env.APIO_COMMIT}}]
 
             For installation instruction see (https://github.com/${{github.repository}}).
 

--- a/.github/workflows/build-all.yaml
+++ b/.github/workflows/build-all.yaml
@@ -119,7 +119,6 @@ jobs:
             body: |
               This is an automated build of the Apio's develop branch.
 
-              | Item         | Value                 |
               | ------------ | --------------------- |
               | Date tag     | ${{env.DATE_TAG}}     |
               | Apio version | ${{env.APIO_VERSION}} |

--- a/.github/workflows/build-all.yaml
+++ b/.github/workflows/build-all.yaml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
 
-# --------------
+  # ----- Parameters collection job
 
   prepare:
 
@@ -70,7 +70,8 @@ jobs:
           echo ${apio_version}
           echo "apio_version=${apio_version}" >> $GITHUB_OUTPUT
 
-  # --------------
+
+  # ----- Children build jobs
 
   build-darwin_arm64:
     needs: prepare
@@ -81,15 +82,28 @@ jobs:
       apio_version: ${{ needs.prepare.outputs.apio_version }}
     secrets: inherit
 
+
   build-linux-x86-64:
     needs: prepare
     uses: ./.github/workflows/build-linux-x86-64.yml
+    with:
+      date_tag: ${{ needs.prepare.outputs.date_tag }}
+      apio_commit: ${{ needs.prepare.outputs.apio_commit }}
+      apio_version: ${{ needs.prepare.outputs.apio_version }}
+    secrets: inherit
+
 
   build-windows-amd64:
     needs: prepare
     uses: ./.github/workflows/build-windows-amd64.yml
+    with:
+      date_tag: ${{ needs.prepare.outputs.date_tag }}
+      apio_commit: ${{ needs.prepare.outputs.apio_commit }}
+      apio_version: ${{ needs.prepare.outputs.apio_version }}
+    secrets: inherit
 
-  # ---------------
+
+  # ----- Release creation job
 
   publish:
       needs: [prepare, build-darwin_arm64, build-linux-x86-64, build-windows-amd64]

--- a/.github/workflows/build-all.yaml
+++ b/.github/workflows/build-all.yaml
@@ -119,6 +119,8 @@ jobs:
             body: |
               This is an automated build of the Apio's develop branch.
 
+              | Item         | Value                 |
+              | ------------ | --------------------- |
               | Date tag     | ${{env.DATE_TAG}}     |
               | Apio version | ${{env.APIO_VERSION}} |
               | Apio commit  | ${{env.APIO_COMMIT}}  |

--- a/.github/workflows/build-all.yaml
+++ b/.github/workflows/build-all.yaml
@@ -126,9 +126,11 @@ jobs:
             body: |
               This is an automated build of the Apio's repo `develop` branch.
 
-              * `DATE_TAG`: ${{env.DATE_TAG}}
-              * `APIO_VERSION`: ${{env.APIO_VERSION}}
-              * `APIO_COMMIT`: ${{env.APIO_COMMIT}}
+              ```
+                  DATE_TAG:      ${{env.DATE_TAG}}
+                  APIO_VERSION:  ${{env.APIO_VERSION}}
+                  APIO_COMMIT:   ${{env.APIO_COMMIT}}
+              ```
 
               Resources
               * [installation instructions](https://github.com/${{github.repository}}).

--- a/.github/workflows/build-all.yaml
+++ b/.github/workflows/build-all.yaml
@@ -86,9 +86,10 @@ jobs:
           name: ${{env.DATE_TAG}}
           body: |
             This is an automated build of the Apio's develop branch.
-            - Date tag:       [${{env.DATE_TAG}}]
-            - Apio version:   [${{env.APIO_VERSION}}]
-            - Apio commit:    [${{env.APIO_COMMIT}}]
+
+            | Date tag     | ${{env.DATE_TAG}}     |
+            | Apio version | ${{env.APIO_VERSION}} |
+            | Apio commit  | ${{env.APIO_COMMIT}}  |
 
             For installation instruction see (https://github.com/${{github.repository}}).
 

--- a/.github/workflows/build-all.yaml
+++ b/.github/workflows/build-all.yaml
@@ -162,8 +162,8 @@ jobs:
 
             files: |
               # Darwin
-              artifacts/apio-darwin-arm64-installer/**
               artifacts/apio-darwin-arm64-bundle/**
+              artifacts/apio-darwin-arm64-installer/**
 
               # Linux
               artifacts/apio-linux-x86-64-bundle/**

--- a/.github/workflows/build-all.yaml
+++ b/.github/workflows/build-all.yaml
@@ -13,30 +13,30 @@ permissions:
   contents: write
 
 jobs:
-  build-darwin:
-    uses: ./.github/workflows/build-darwin-arm64.yml
 
-  build-linux:
-    uses: ./.github/workflows/build-linux-x86-64.yml
 
-  build-windows:
-    uses: ./.github/workflows/build-windows-amd64.yml
-
-  publish:
-    needs: [build-darwin, build-linux, build-windows]
+  prepare:
+    # needs: [build-darwin, build-linux, build-windows]
 
     runs-on: ubuntu-latest
+
+    outputs:
+      date_tag: ${{ steps.get_date_tag.outputs.get_tag }}
+      apio_commit: ${{ steps.get_apio_commit.outputs.apio_commit }}
+      apio_version: ${{ steps.get_apio_version.outputs.apio_version }}
 
     env:
       DATE_TAG: date-tag-tbd
 
     steps:
 
-      - name: Create date tag
+      - name: Get date tag
+        id: get_date_tag
         run: |
           date_tag="$(date +'%Y-%m-%d')"
           echo "${date_tag}"
-          echo "DATE_TAG=${date_tag}" >> "$GITHUB_ENV"
+          # echo "DATE_TAG=${date_tag}" >> "$GITHUB_ENV"
+          echo "date_tag=${date_tag}" >> "$GITHUB_OUTPUT"
 
 
       - name: Checkout the apio repo
@@ -49,10 +49,12 @@ jobs:
 
 
       - name: Get apio commit SHA.
+        id: get_apio_commit
         run: |
           apio_commit=$(git -C apio-repo rev-parse HEAD)
           echo "${apio_commit}"
-          echo "APIO_COMMIT=${apio_commit}" >> "$GITHUB_ENV"
+          # echo "APIO_COMMIT=${apio_commit}" >> "$GITHUB_ENV"
+          echo "apio_commit=${apio_commit}" >> "$GITHUB_OUTPUT"
 
 
       - name: Pip install apio.
@@ -61,50 +63,85 @@ jobs:
           pip install -e apio-repo
 
 
-      - name: Extract apio version
+      - name: Get apio version
+        id: get_apio_version
         run: |
           apio_version="$(pip show apio | grep Version: | cut -d ' ' -f2)"
           echo ${apio_version}
-          echo "APIO_VERSION=${apio_version}" >> $GITHUB_ENV
+          # echo "APIO_VERSION=${apio_version}" >> $GITHUB_ENV
+          echo "apio_version=${apio_version}" >> $GITHUB_OUTPUT
+
+  # ----------------
 
 
-      - name: Download the build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: artifacts
+  build-darwin:
+    needs: prepare
+    uses: ./.github/workflows/build-darwin-arm64.yml
+
+  build-linux:
+    needs: prepare
+    uses: ./.github/workflows/build-linux-x86-64.yml
+
+  build-windows:
+    needs: prepare
+    uses: ./.github/workflows/build-windows-amd64.yml
 
 
-      - name: List files
-        run: |
-          find artifacts
+  # ---------------
+
+  publish:
+      needs: [build-darwin, build-linux, build-windows]
+
+      runs-on: ubuntu-latest
+
+      env:
+        DATE_TAG: date-tag-tbd
+
+      steps:
+
+        - name: Init env.
+          run: |
+            echo "date_tag=${{ needs.prepare.outputs.date_tag }}" >> "$GITHUB_ENV"
+            echo "apio_commit=${{ needs.prepare.outputs.apio_version }}" >> "$GITHUB_ENV"
+            echo "apio_version=${{ needs.prepare.outputs.apio_version }}" >> "$GITHUB_ENV"
+
+        - name: Download the build artifacts
+          uses: actions/download-artifact@v4
+          with:
+            path: artifacts
 
 
-      - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{env.DATE_TAG}}
-          name: ${{env.DATE_TAG}}
-          body: |
-            This is an automated build of the Apio's develop branch.
+        - name: List files
+          run: |
+            find artifacts
 
-            | Date tag     | ${{env.DATE_TAG}}     |
-            | Apio version | ${{env.APIO_VERSION}} |
-            | Apio commit  | ${{env.APIO_COMMIT}}  |
 
-            For installation instruction see (https://github.com/${{github.repository}}).
+        - name: Create GitHub release
+          uses: softprops/action-gh-release@v2
+          with:
+            tag_name: ${{env.DATE_TAG}}
+            name: ${{env.DATE_TAG}}
+            body: |
+              This is an automated build of the Apio's develop branch.
 
-            For the official releases see (https://github.com/FPGAwars/apio/releases).
+              | Date tag     | ${{env.DATE_TAG}}     |
+              | Apio version | ${{env.APIO_VERSION}} |
+              | Apio commit  | ${{env.APIO_COMMIT}}  |
 
-          files: |
-            # Darwin
-            artifacts/apio-darwin-arm64-bundle/**
-            artifacts/apio-darwin-arm64-installer/**
+              For installation instruction see (https://github.com/${{github.repository}}).
 
-            # Linux
-            artifacts/apio-linux-x86-64-bundle/**
-            artifacts/apio-linux-x86-64-debian/**
+              For the official releases see (https://github.com/FPGAwars/apio/releases).
 
-            # Windows
-            artifacts/apio-windows-amd64-bundle/**
-            artifacts/apio-windows-amd64-installer/**
+            files: |
+              # Darwin
+              artifacts/apio-darwin-arm64-bundle/**
+              artifacts/apio-darwin-arm64-installer/**
+
+              # Linux
+              artifacts/apio-linux-x86-64-bundle/**
+              artifacts/apio-linux-x86-64-debian/**
+
+              # Windows
+              artifacts/apio-windows-amd64-bundle/**
+              artifacts/apio-windows-amd64-installer/**
 

--- a/.github/workflows/build-all.yaml
+++ b/.github/workflows/build-all.yaml
@@ -7,10 +7,12 @@ on:
   # Allow manual activations.
   workflow_dispatch:
 
-
 permissions:
   # Allow release creation
   contents: write
+
+env:
+  APIO_REPO: 'FPGAwars/apio'
 
 jobs:
 
@@ -43,10 +45,10 @@ jobs:
       - name: Checkout the apio repo
         uses: actions/checkout@v4
         with:
-          repository: FPGAwars/apio
-          # repository: zapta/apio-dev
+          repository: ${{env.APIO_REPO}}
           ref: develop
           path: apio-repo
+          fetch-depth: 0
 
 
       - name: Get apio commit SHA
@@ -143,14 +145,16 @@ jobs:
               This is an automated build of the Apio's repo `develop` branch.
 
               ```
-                  APIO_TAG:      ${{env.APIO_TAG}}
-                  APIO_VERSION:  ${{env.APIO_VERSION}}
-                  APIO_COMMIT:   ${{env.APIO_COMMIT}}
+                  APIO_REPO:     [${{env.APIO_REPO}}]
+                  APIO_TAG:      [${{env.APIO_TAG}}]
+                  APIO_VERSION:  [${{env.APIO_VERSION}}]
+                  APIO_COMMIT:   [${{env.APIO_COMMIT}}]
               ```
 
               Resources
               * [installation instructions](https://github.com/${{github.repository}}).
               * [Official Apio releases](https://github.com/FPGAwars/apio/releases).
+              * [Last commit](https://github.com/${{env.APIO_REPO}}/commit/${{env.APIO_COMMIT}})
 
             files: |
               # Darwin

--- a/.github/workflows/build-all.yaml
+++ b/.github/workflows/build-all.yaml
@@ -17,7 +17,6 @@ jobs:
 # --------------
 
   prepare:
-    # needs: [build-darwin, build-linux, build-windows]
 
     runs-on: ubuntu-latest
 
@@ -71,22 +70,22 @@ jobs:
 
   # --------------
 
-  build-darwin:
+  build-darwin_arm64:
     needs: prepare
     uses: ./.github/workflows/build-darwin-arm64.yml
 
-  build-linux:
+  build-linux-x86-64:
     needs: prepare
     uses: ./.github/workflows/build-linux-x86-64.yml
 
-  build-windows:
+  build-windows-amd64:
     needs: prepare
     uses: ./.github/workflows/build-windows-amd64.yml
 
   # ---------------
 
   publish:
-      needs: [prepare, build-darwin, build-linux, build-windows]
+      needs: [prepare, build-darwin_arm64, build-linux-x86-64, build-windows-amd64]
 
       runs-on: ubuntu-latest
 
@@ -95,7 +94,7 @@ jobs:
 
       steps:
 
-        - name: Init env.
+        - name: Setup env.
           run: |
             echo "DATE_TAG=${{ needs.prepare.outputs.date_tag }}" >> "$GITHUB_ENV"
             echo "APIO_COMMIT=${{ needs.prepare.outputs.apio_version }}" >> "$GITHUB_ENV"
@@ -107,7 +106,7 @@ jobs:
             path: artifacts
 
 
-        - name: List files
+        - name: List artifact files
           run: |
             find artifacts
 

--- a/.github/workflows/build-darwin-arm64.yml
+++ b/.github/workflows/build-darwin-arm64.yml
@@ -3,7 +3,7 @@ name: build-darwin-arm64
 on:
   workflow_call:
     inputs:
-      date_tag:
+      apio_tag:
         required: true
         type: string
       apio_commit:
@@ -23,7 +23,7 @@ jobs:
       installer: "apio-darwin-arm64-installer"
 
     env:
-      DATE_TAG: value-tbd
+      APIO_TAG: value-tbd
       APIO_COMMIT: value-tbd
       APIO_VERSION: value-tbd
 
@@ -37,15 +37,9 @@ jobs:
 
       - name: Set up env
         run: |
-          echo "DATE_TAG=${{inputs.date_tag}}" >> "$GITHUB_ENV"
+          echo "APIO_TAG=${{inputs.apio_tag}}" >> "$GITHUB_ENV"
           echo "APIO_COMMIT=${{inputs.apio_commit}}" >> "$GITHUB_ENV"
           echo "APIO_VERSION=${{inputs.apio_version}}" >> "$GITHUB_ENV"
-
-      # - name: Create date tag
-      #   run: |
-      #     date_tag="$(date +'%Y-%m-%d')"
-      #     echo "${date_tag}"
-      #     echo "DATE_TAG=${date_tag}" >> "$GITHUB_ENV"
 
 
       - name: Install python
@@ -91,13 +85,6 @@ jobs:
           cat -n $f
           sed -i.bak "/'usb':/d" "$f" && rm -f "${f}.bak"
           cat -n $f
-
-
-      # - name: Extract apio version
-      #   run: |
-      #     apio_version="$(pip show apio | grep Version: | cut -d ' ' -f2)"
-      #     echo ${apio_version}
-      #     echo "APIO_VERSION=${apio_version}" >> $GITHUB_ENV
 
 
       - name: Set up working directories
@@ -158,7 +145,7 @@ jobs:
       - name: Zip the pyinstaller bundle
         run: |
           pushd _dist
-          bundle="apio-darwin-arm64-${APIO_VERSION}-${DATE_TAG}-bundle.zip"
+          bundle="apio-darwin-arm64-${APIO_VERSION}-${APIO_TAG}-bundle.zip"
           zip -r -y ../${bundle} apio
           popd
           ls -al
@@ -207,7 +194,7 @@ jobs:
           productbuild --resources apio-dev-build-repo/.github/workflows/darwin-resources \
                        --distribution apio-dev-build-repo/.github/workflows/darwin-resources/distribution.xml \
                        --package-path . \
-                       "apio-darwin-arm64-${APIO_VERSION}-${DATE_TAG}-installer.pkg"
+                       "apio-darwin-arm64-${APIO_VERSION}-${APIO_TAG}-installer.pkg"
           pwd
           ls -al
 
@@ -217,7 +204,7 @@ jobs:
         with:
           if-no-files-found: error
           name: "apio-darwin-arm64-bundle"
-          path: "apio-darwin-arm64-${{env.APIO_VERSION}}-${{env.DATE_TAG}}-bundle.zip"
+          path: "apio-darwin-arm64-${{env.APIO_VERSION}}-${{env.APIO_TAG}}-bundle.zip"
 
 
       - name: Export the installer file as an artifact
@@ -225,5 +212,5 @@ jobs:
         with:
           if-no-files-found: error
           name: "apio-darwin-arm64-installer"
-          path: "apio-darwin-arm64-${{env.APIO_VERSION}}-${{env.DATE_TAG}}-installer.pkg"
+          path: "apio-darwin-arm64-${{env.APIO_VERSION}}-${{env.APIO_TAG}}-installer.pkg"
 

--- a/.github/workflows/build-darwin-arm64.yml
+++ b/.github/workflows/build-darwin-arm64.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Log architecture info
         run: uname -m
 
-      - name: Set up env.
+      - name: Set up env
         run: |
           echo "DATE_TAG=${{inputs.date_tag}}" >> "$GITHUB_ENV"
           echo "APIO_COMMIT=${{inputs.apio_commit}}" >> "$GITHUB_ENV"
@@ -80,7 +80,7 @@ jobs:
           fetch-depth: 0
 
 
-      - name: Pip install apio.
+      - name: Pip install apio
         run: |
           python -m pip install --upgrade pip
           pip install -e apio-repo
@@ -111,7 +111,7 @@ jobs:
       #     echo "APIO_VERSION=${apio_version}" >> $GITHUB_ENV
 
 
-      - name: Setup working directories.
+      - name: Set up working directories
         run: |
           mkdir _work
           mkdir _dist
@@ -223,7 +223,7 @@ jobs:
           ls -al
 
 
-      - name: Export the pyinstaller bundle as an artifact.
+      - name: Export the pyinstaller bundle as an artifact
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
@@ -231,7 +231,7 @@ jobs:
           path: "apio-darwin-arm64-${{env.APIO_VERSION}}-${{env.DATE_TAG}}-bundle.zip"
 
 
-      - name: Export the installer file as an artifact.
+      - name: Export the installer file as an artifact
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error

--- a/.github/workflows/build-darwin-arm64.yml
+++ b/.github/workflows/build-darwin-arm64.yml
@@ -34,8 +34,9 @@ jobs:
       installer: "apio-darwin-arm64-installer"
 
     env:
-      DATE_TAG: date-tag-tbd
-      APIO_VERSION: apio-version-rbd
+      DATE_TAG: value-tbd
+      APIO_COMMIT: value-tbd
+      APIO_CERSION: value-tbd
 
     defaults:
       run:
@@ -45,9 +46,9 @@ jobs:
       - name: Log architecture info
         run: uname -m
 
-      - name: Setup env.
+      - name: Set up env.
         run: |
-          echo "DATE_TAG=${{inputs.apio_version}}" >> "$GITHUB_ENV"
+          echo "DATE_TAG=${{inputs.date_tag}}" >> "$GITHUB_ENV"
           echo "APIO_COMMIT=${{inputs.apio_commit}}" >> "$GITHUB_ENV"
           echo "APIO_VERSION=${{inputs.apio_version}}" >> "$GITHUB_ENV"
 

--- a/.github/workflows/build-darwin-arm64.yml
+++ b/.github/workflows/build-darwin-arm64.yml
@@ -2,16 +2,16 @@ name: build-darwin-arm64
 
 on:
   # Run on each commit to this repo.
-  push:
+  # push:
 
-  # Run every day at 2AM.
-  schedule:
-    - cron: '0 2 * * *'
+  # # Run every day at 2AM.
+  # schedule:
+  #   - cron: '0 2 * * *'
 
   # Allow manual activations.
-  workflow_dispatch:
+  # workflow_dispatch:
 
-  # Can be called by other workflow.
+  # Called with input parameters.
   workflow_call:
 
 

--- a/.github/workflows/build-darwin-arm64.yml
+++ b/.github/workflows/build-darwin-arm64.yml
@@ -11,8 +11,18 @@ on:
   # Allow manual activations.
   # workflow_dispatch:
 
-  # Called with input parameters.
+  # Called with required input parameters.
   workflow_call:
+    inputs:
+      date_tag:
+        required: true
+        type: string
+      apio_commit:
+        required: true
+        type: string
+      apio_version:
+        required: true
+        type: string
 
 
 jobs:
@@ -35,12 +45,17 @@ jobs:
       - name: Log architecture info
         run: uname -m
 
-
-      - name: Create date tag
+      - name: Setup env.
         run: |
-          date_tag="$(date +'%Y-%m-%d')"
-          echo "${date_tag}"
-          echo "DATE_TAG=${date_tag}" >> "$GITHUB_ENV"
+          echo "DATE_TAG=${{inputs.apio_version}}" >> "$GITHUB_ENV"
+          echo "APIO_COMMIT=${{inputs.apio_commit}}" >> "$GITHUB_ENV"
+          echo "APIO_VERSION=${{inputs.apio_version}}" >> "$GITHUB_ENV"
+
+      # - name: Create date tag
+      #   run: |
+      #     date_tag="$(date +'%Y-%m-%d')"
+      #     echo "${date_tag}"
+      #     echo "DATE_TAG=${date_tag}" >> "$GITHUB_ENV"
 
 
       - name: Install python
@@ -59,9 +74,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: FPGAwars/apio
-          # repository: zapta/apio-dev
           ref: develop
           path: apio-repo
+          fetch-depth: 0
 
 
       - name: Pip install apio.
@@ -88,11 +103,11 @@ jobs:
           cat -n $f
 
 
-      - name: Extract apio version
-        run: |
-          apio_version="$(pip show apio | grep Version: | cut -d ' ' -f2)"
-          echo ${apio_version}
-          echo "APIO_VERSION=${apio_version}" >> $GITHUB_ENV
+      # - name: Extract apio version
+      #   run: |
+      #     apio_version="$(pip show apio | grep Version: | cut -d ' ' -f2)"
+      #     echo ${apio_version}
+      #     echo "APIO_VERSION=${apio_version}" >> $GITHUB_ENV
 
 
       - name: Setup working directories.

--- a/.github/workflows/build-darwin-arm64.yml
+++ b/.github/workflows/build-darwin-arm64.yml
@@ -1,17 +1,6 @@
 name: build-darwin-arm64
 
 on:
-  # Run on each commit to this repo.
-  # push:
-
-  # # Run every day at 2AM.
-  # schedule:
-  #   - cron: '0 2 * * *'
-
-  # Allow manual activations.
-  # workflow_dispatch:
-
-  # Called with required input parameters.
   workflow_call:
     inputs:
       date_tag:

--- a/.github/workflows/build-darwin-arm64.yml
+++ b/.github/workflows/build-darwin-arm64.yml
@@ -25,7 +25,7 @@ jobs:
     env:
       DATE_TAG: value-tbd
       APIO_COMMIT: value-tbd
-      APIO_CERSION: value-tbd
+      APIO_VERSION: value-tbd
 
     defaults:
       run:

--- a/.github/workflows/build-darwin-arm64.yml
+++ b/.github/workflows/build-darwin-arm64.yml
@@ -3,6 +3,9 @@ name: build-darwin-arm64
 on:
   workflow_call:
     inputs:
+      apio_repo:
+        required: true
+        type: string
       apio_tag:
         required: true
         type: string
@@ -23,6 +26,7 @@ jobs:
       installer: "apio-darwin-arm64-installer"
 
     env:
+      APIO_REPO: value-tbd
       APIO_TAG: value-tbd
       APIO_COMMIT: value-tbd
       APIO_VERSION: value-tbd
@@ -37,6 +41,7 @@ jobs:
 
       - name: Set up env
         run: |
+          echo "APIO_REPO=${{inputs.apio_repo}}" >> "$GITHUB_ENV"
           echo "APIO_TAG=${{inputs.apio_tag}}" >> "$GITHUB_ENV"
           echo "APIO_COMMIT=${{inputs.apio_commit}}" >> "$GITHUB_ENV"
           echo "APIO_VERSION=${{inputs.apio_version}}" >> "$GITHUB_ENV"
@@ -57,8 +62,8 @@ jobs:
       - name: Checkout the apio repo
         uses: actions/checkout@v4
         with:
-          repository: FPGAwars/apio
-          ref: develop
+          repository: ${{env.APIO_REPO}}
+          ref: ${{env.APIO_COMMIT}}
           path: apio-repo
           fetch-depth: 0
 

--- a/.github/workflows/build-darwin-arm64.yml
+++ b/.github/workflows/build-darwin-arm64.yml
@@ -58,8 +58,8 @@ jobs:
       - name: Checkout the apio repo
         uses: actions/checkout@v4
         with:
-          # repository: FPGAwars/apio
-          repository: zapta/apio-dev
+          repository: FPGAwars/apio
+          # repository: zapta/apio-dev
           ref: develop
           path: apio-repo
 

--- a/.github/workflows/build-linux-x86-64.yml
+++ b/.github/workflows/build-linux-x86-64.yml
@@ -4,6 +4,9 @@ name: build-linux-x86-64
 on:
   workflow_call:
     inputs:
+      apio_repo:
+        required: true
+        type: string
       apio_tag:
         required: true
         type: string
@@ -24,6 +27,7 @@ jobs:
       debian:  "apio-linux-x86-64-debian"
 
     env:
+      APIO_REPO: value-tbd
       APIO_TAG: value-tbd
       APIO_COMMIT: value-tbd
       APIO_VERSION: value-tbd
@@ -40,6 +44,7 @@ jobs:
 
       - name: Set up env
         run: |
+          echo "APIO_REPO=${{inputs.apio_repo}}" >> "$GITHUB_ENV"
           echo "APIO_TAG=${{inputs.apio_tag}}" >> "$GITHUB_ENV"
           echo "APIO_COMMIT=${{inputs.apio_commit}}" >> "$GITHUB_ENV"
           echo "APIO_VERSION=${{inputs.apio_version}}" >> "$GITHUB_ENV"
@@ -60,9 +65,8 @@ jobs:
       - name: Checkout the apio repo
         uses: actions/checkout@v4
         with:
-          repository: FPGAwars/apio
-          # repository: zapta/apio-dev
-          ref: develop
+          repository: ${{env.APIO_REPO}}
+          ref: ${{env.APIO_COMMIT}}
           path: apio-repo
           fetch-depth: 0
 

--- a/.github/workflows/build-linux-x86-64.yml
+++ b/.github/workflows/build-linux-x86-64.yml
@@ -4,7 +4,7 @@ name: build-linux-x86-64
 on:
   workflow_call:
     inputs:
-      date_tag:
+      apio_tag:
         required: true
         type: string
       apio_commit:
@@ -24,7 +24,7 @@ jobs:
       debian:  "apio-linux-x86-64-debian"
 
     env:
-      DATE_TAG: value-tbd
+      APIO_TAG: value-tbd
       APIO_COMMIT: value-tbd
       APIO_VERSION: value-tbd
 
@@ -40,16 +40,9 @@ jobs:
 
       - name: Set up env
         run: |
-          echo "DATE_TAG=${{inputs.date_tag}}" >> "$GITHUB_ENV"
+          echo "APIO_TAG=${{inputs.apio_tag}}" >> "$GITHUB_ENV"
           echo "APIO_COMMIT=${{inputs.apio_commit}}" >> "$GITHUB_ENV"
           echo "APIO_VERSION=${{inputs.apio_version}}" >> "$GITHUB_ENV"
-
-
-      # - name: Create date tag
-      #   run: |
-      #     date_tag="$(date +'%Y-%m-%d')"
-      #     echo "${date_tag}"
-      #     echo "DATE_TAG=${date_tag}" >> "$GITHUB_ENV"
 
 
       - name: Install python
@@ -95,13 +88,6 @@ jobs:
           cat -n $f
           sed -i.bak "/'usb':/d" "$f" && rm -f "${f}.bak"
           cat -n $f
-
-
-      # - name: Extract apio version
-      #   run: |
-      #     apio_version="$(pip show apio | grep Version: | cut -d ' ' -f2)"
-      #     echo ${apio_version}
-      #     echo "APIO_VERSION=${apio_version}" >> $GITHUB_ENV
 
 
       - name: Set up working directories
@@ -164,7 +150,7 @@ jobs:
       - name: Zip the pyinstaller bundle
         run: |
           pushd _dist
-          bundle="apio-linux-x86-64-${APIO_VERSION}-${DATE_TAG}-bundle.zip"
+          bundle="apio-linux-x86-64-${APIO_VERSION}-${APIO_TAG}-bundle.zip"
           zip -r -y ../${bundle} apio
           popd
           ls -al
@@ -199,7 +185,7 @@ jobs:
 
       - name: Build .deb package
         run: |
-          dpkg-deb --build --root-owner-group _debian "apio-linux-x86-64-${APIO_VERSION}-${DATE_TAG}-debian.deb"
+          dpkg-deb --build --root-owner-group _debian "apio-linux-x86-64-${APIO_VERSION}-${APIO_TAG}-debian.deb"
           ls -l
 
 
@@ -208,7 +194,7 @@ jobs:
         with:
           if-no-files-found: error
           name: "apio-linux-x86-64-bundle"
-          path: "apio-linux-x86-64-${{env.APIO_VERSION}}-${{env.DATE_TAG}}-bundle.zip"
+          path: "apio-linux-x86-64-${{env.APIO_VERSION}}-${{env.APIO_TAG}}-bundle.zip"
 
 
       - name: Export the installer file as an artifact
@@ -216,5 +202,5 @@ jobs:
         with:
           if-no-files-found: error
           name: "apio-linux-x86-64-debian"
-          path: "apio-linux-x86-64-${{env.APIO_VERSION}}-${{env.DATE_TAG}}-debian.deb"
+          path: "apio-linux-x86-64-${{env.APIO_VERSION}}-${{env.APIO_TAG}}-debian.deb"
 

--- a/.github/workflows/build-linux-x86-64.yml
+++ b/.github/workflows/build-linux-x86-64.yml
@@ -67,7 +67,7 @@ jobs:
           path: apio-repo
           fetch-depth: 0
 
-      - name: Pip install apio.
+      - name: Pip install apio
         run: |
           python -m pip install --upgrade pip
           pip install -e apio-repo
@@ -98,7 +98,7 @@ jobs:
           echo "APIO_VERSION=${apio_version}" >> $GITHUB_ENV
 
 
-      - name: Setup working directories.
+      - name: Set up working directories
         run: |
           mkdir _work
           mkdir _dist
@@ -197,7 +197,7 @@ jobs:
           ls -l
 
 
-      - name: Export the pyinstaller archive as an artifact.
+      - name: Export the pyinstaller archive as an artifact
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
@@ -205,7 +205,7 @@ jobs:
           path: "apio-linux-x86-64-${{env.APIO_VERSION}}-${{env.DATE_TAG}}-bundle.zip"
 
 
-      - name: Export the installer file as an artifact.
+      - name: Export the installer file as an artifact
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error

--- a/.github/workflows/build-linux-x86-64.yml
+++ b/.github/workflows/build-linux-x86-64.yml
@@ -3,16 +3,16 @@ name: build-linux-x86-64
 
 on:
   # Run on each commit to this repo.
-  push:
+  # push:
 
   # Run every day at 2AM.
-  schedule:
-    - cron: '0 2 * * *'
+  # schedule:
+  #   - cron: '0 2 * * *'
 
-  # Allow manual activations.
-  workflow_dispatch:
+  # # Allow manual activations.
+  # workflow_dispatch:
 
-  # Can be called by other workflow.
+  # Called with input parameters.
   workflow_call:
 
 

--- a/.github/workflows/build-linux-x86-64.yml
+++ b/.github/workflows/build-linux-x86-64.yml
@@ -26,7 +26,7 @@ jobs:
     env:
       DATE_TAG: value-tbd
       APIO_COMMIT: value-tbd
-      APIO_CERSION: value-tbd
+      APIO_VERSION: value-tbd
 
     defaults:
       run:

--- a/.github/workflows/build-linux-x86-64.yml
+++ b/.github/workflows/build-linux-x86-64.yml
@@ -25,8 +25,9 @@ jobs:
       debian:  "apio-linux-x86-64-debian"
 
     env:
-      DATE_TAG: date-tag-tbd
-      APIO_VERSION: apio-version-tbd
+      DATE_TAG: value-tbd
+      APIO_COMMIT: value-tbd
+      APIO_CERSION: value-tbd
 
     defaults:
       run:

--- a/.github/workflows/build-linux-x86-64.yml
+++ b/.github/workflows/build-linux-x86-64.yml
@@ -2,18 +2,17 @@ name: build-linux-x86-64
 
 
 on:
-  # Run on each commit to this repo.
-  # push:
-
-  # Run every day at 2AM.
-  # schedule:
-  #   - cron: '0 2 * * *'
-
-  # # Allow manual activations.
-  # workflow_dispatch:
-
-  # Called with input parameters.
   workflow_call:
+    inputs:
+      date_tag:
+        required: true
+        type: string
+      apio_commit:
+        required: true
+        type: string
+      apio_version:
+        required: true
+        type: string
 
 
 jobs:
@@ -39,11 +38,18 @@ jobs:
         run: uname -m
 
 
-      - name: Create date tag
+      - name: Set up env
         run: |
-          date_tag="$(date +'%Y-%m-%d')"
-          echo "${date_tag}"
-          echo "DATE_TAG=${date_tag}" >> "$GITHUB_ENV"
+          echo "DATE_TAG=${{inputs.date_tag}}" >> "$GITHUB_ENV"
+          echo "APIO_COMMIT=${{inputs.apio_commit}}" >> "$GITHUB_ENV"
+          echo "APIO_VERSION=${{inputs.apio_version}}" >> "$GITHUB_ENV"
+
+
+      # - name: Create date tag
+      #   run: |
+      #     date_tag="$(date +'%Y-%m-%d')"
+      #     echo "${date_tag}"
+      #     echo "DATE_TAG=${date_tag}" >> "$GITHUB_ENV"
 
 
       - name: Install python
@@ -91,11 +97,11 @@ jobs:
           cat -n $f
 
 
-      - name: Extract apio version
-        run: |
-          apio_version="$(pip show apio | grep Version: | cut -d ' ' -f2)"
-          echo ${apio_version}
-          echo "APIO_VERSION=${apio_version}" >> $GITHUB_ENV
+      # - name: Extract apio version
+      #   run: |
+      #     apio_version="$(pip show apio | grep Version: | cut -d ' ' -f2)"
+      #     echo ${apio_version}
+      #     echo "APIO_VERSION=${apio_version}" >> $GITHUB_ENV
 
 
       - name: Set up working directories

--- a/.github/workflows/build-linux-x86-64.yml
+++ b/.github/workflows/build-linux-x86-64.yml
@@ -60,8 +60,8 @@ jobs:
       - name: Checkout the apio repo
         uses: actions/checkout@v4
         with:
-          # repository: FPGAwars/apio
-          repository: zapta/apio-dev
+          repository: FPGAwars/apio
+          # repository: zapta/apio-dev
           ref: develop
           path: apio-repo
 

--- a/.github/workflows/build-linux-x86-64.yml
+++ b/.github/workflows/build-linux-x86-64.yml
@@ -64,7 +64,7 @@ jobs:
           # repository: zapta/apio-dev
           ref: develop
           path: apio-repo
-
+          fetch-depth: 0
 
       - name: Pip install apio.
         run: |

--- a/.github/workflows/build-windows-amd64.yml
+++ b/.github/workflows/build-windows-amd64.yml
@@ -68,7 +68,7 @@ jobs:
           fetch-depth: 0
 
 
-      - name: Pip install apio.
+      - name: Pip install apio
         run: |
           python -m pip install --upgrade pip
           pip install -e apio-repo
@@ -99,7 +99,7 @@ jobs:
           echo "APIO_VERSION=${apio_version}" >> $GITHUB_ENV
 
 
-      - name: Setup working directories.
+      - name: Set up working directories
         run: |
           mkdir _work
           mkdir _dist
@@ -157,7 +157,7 @@ jobs:
           Get-ChildItem -Force
 
 
-      - name: Create innosetup.iss.
+      - name: Create innosetup.iss
         run: |
           out="innosetup.iss"
           sed "s/\[APIO_VERSION\]/${APIO_VERSION}/g" apio-dev-build-repo/.github/workflows/windows-resources/innosetup.template > ${out}
@@ -176,7 +176,7 @@ jobs:
           mv innosetup-installer.exe "apio-windows-amd64-${APIO_VERSION}-${DATE_TAG}-installer.exe"
           ls -al
 
-      - name: Export the pyinstaller bundle as an artifact.
+      - name: Export the pyinstaller bundle as an artifact
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error
@@ -184,7 +184,7 @@ jobs:
           path: "apio-windows-amd64-${{env.APIO_VERSION}}-${{env.DATE_TAG}}-bundle.zip"
 
 
-      - name: Export the installer file as an artifact.
+      - name: Export the installer file as an artifact
         uses: actions/upload-artifact@v4
         with:
           if-no-files-found: error

--- a/.github/workflows/build-windows-amd64.yml
+++ b/.github/workflows/build-windows-amd64.yml
@@ -3,16 +3,16 @@ name: build-windows-amd64
 
 on:
   # Run on each commit to this repo.
-  push:
+  # push:
 
   # Run every day at 2AM.
-  schedule:
-    - cron: '0 2 * * *'
+  # schedule:
+  #   - cron: '0 2 * * *'
 
-  # Allow manual activations.
-  workflow_dispatch:
+  # # Allow manual activations.
+  # workflow_dispatch:
 
-  # Can be called by other workflow.
+  # Called with input parameters.
   workflow_call:
 
 

--- a/.github/workflows/build-windows-amd64.yml
+++ b/.github/workflows/build-windows-amd64.yml
@@ -2,18 +2,17 @@ name: build-windows-amd64
 
 
 on:
-  # Run on each commit to this repo.
-  # push:
-
-  # Run every day at 2AM.
-  # schedule:
-  #   - cron: '0 2 * * *'
-
-  # # Allow manual activations.
-  # workflow_dispatch:
-
-  # Called with input parameters.
   workflow_call:
+    inputs:
+      date_tag:
+        required: true
+        type: string
+      apio_commit:
+        required: true
+        type: string
+      apio_version:
+        required: true
+        type: string
 
 
 jobs:
@@ -39,11 +38,17 @@ jobs:
           systeminfo
 
 
-      - name: Create date tag
+      - name: Set up env
         run: |
-          date_tag="$(date +'%Y-%m-%d')"
-          echo "${date_tag}"
-          echo "DATE_TAG=${date_tag}" >> "$GITHUB_ENV"
+          echo "DATE_TAG=${{inputs.date_tag}}" >> "$GITHUB_ENV"
+          echo "APIO_COMMIT=${{inputs.apio_commit}}" >> "$GITHUB_ENV"
+          echo "APIO_VERSION=${{inputs.apio_version}}" >> "$GITHUB_ENV"
+
+      # - name: Create date tag
+      #   run: |
+      #     date_tag="$(date +'%Y-%m-%d')"
+      #     echo "${date_tag}"
+      #     echo "DATE_TAG=${date_tag}" >> "$GITHUB_ENV"
 
 
       - name: Install python
@@ -92,11 +97,11 @@ jobs:
           cat -n $f
 
 
-      - name: Extract apio version
-        run: |
-          apio_version="$(pip show apio | grep Version: | cut -d ' ' -f2)"
-          echo ${apio_version}
-          echo "APIO_VERSION=${apio_version}" >> $GITHUB_ENV
+      # - name: Extract apio version
+      #   run: |
+      #     apio_version="$(pip show apio | grep Version: | cut -d ' ' -f2)"
+      #     echo ${apio_version}
+      #     echo "APIO_VERSION=${apio_version}" >> $GITHUB_ENV
 
 
       - name: Set up working directories

--- a/.github/workflows/build-windows-amd64.yml
+++ b/.github/workflows/build-windows-amd64.yml
@@ -4,6 +4,9 @@ name: build-windows-amd64
 on:
   workflow_call:
     inputs:
+      apio_repo:
+        required: true
+        type: string
       apio_tag:
         required: true
         type: string
@@ -24,6 +27,7 @@ jobs:
       installer:  "apio-windows-amd64-installer"
 
     env:
+      APIO_REPO: value-tbd
       APIO_TAG: value-tbd
       APIO_COMMIT: value-tbd
       APIO_VERSION: value-tbd
@@ -40,6 +44,7 @@ jobs:
 
       - name: Set up env
         run: |
+          echo "APIO_REPO=${{inputs.apio_repo}}" >> "$GITHUB_ENV"
           echo "APIO_TAG=${{inputs.apio_tag}}" >> "$GITHUB_ENV"
           echo "APIO_COMMIT=${{inputs.apio_commit}}" >> "$GITHUB_ENV"
           echo "APIO_VERSION=${{inputs.apio_version}}" >> "$GITHUB_ENV"
@@ -60,9 +65,8 @@ jobs:
       - name: Checkout the apio repo
         uses: actions/checkout@v4
         with:
-          repository: FPGAwars/apio
-          # repository: zapta/apio-dev
-          ref: develop
+          repository: ${{env.APIO_REPO}}
+          ref: ${{env.APIO_COMMIT}}
           path: apio-repo
           fetch-depth: 0
 

--- a/.github/workflows/build-windows-amd64.yml
+++ b/.github/workflows/build-windows-amd64.yml
@@ -26,7 +26,7 @@ jobs:
     env:
       DATE_TAG: value-tbd
       APIO_COMMIT: value-tbd
-      APIO_CERSION: value-tbd
+      APIO_VERSION: value-tbd
 
     defaults:
       run:

--- a/.github/workflows/build-windows-amd64.yml
+++ b/.github/workflows/build-windows-amd64.yml
@@ -64,7 +64,8 @@ jobs:
           # repository: zapta/apio-dev
           ref: develop
           path: apio-repo
-
+          fetch-depth: 0
+          
 
       - name: Pip install apio.
         run: |

--- a/.github/workflows/build-windows-amd64.yml
+++ b/.github/workflows/build-windows-amd64.yml
@@ -25,8 +25,9 @@ jobs:
       installer:  "apio-windows-amd64-installer"
 
     env:
-      DATE_TAG: date-tag-tbd
-      APIO_VERSION: apio-version-rbd
+      DATE_TAG: value-tbd
+      APIO_COMMIT: value-tbd
+      APIO_CERSION: value-tbd
 
     defaults:
       run:
@@ -65,7 +66,7 @@ jobs:
           ref: develop
           path: apio-repo
           fetch-depth: 0
-          
+
 
       - name: Pip install apio.
         run: |

--- a/.github/workflows/build-windows-amd64.yml
+++ b/.github/workflows/build-windows-amd64.yml
@@ -4,7 +4,7 @@ name: build-windows-amd64
 on:
   workflow_call:
     inputs:
-      date_tag:
+      apio_tag:
         required: true
         type: string
       apio_commit:
@@ -24,7 +24,7 @@ jobs:
       installer:  "apio-windows-amd64-installer"
 
     env:
-      DATE_TAG: value-tbd
+      APIO_TAG: value-tbd
       APIO_COMMIT: value-tbd
       APIO_VERSION: value-tbd
 
@@ -40,15 +40,9 @@ jobs:
 
       - name: Set up env
         run: |
-          echo "DATE_TAG=${{inputs.date_tag}}" >> "$GITHUB_ENV"
+          echo "APIO_TAG=${{inputs.apio_tag}}" >> "$GITHUB_ENV"
           echo "APIO_COMMIT=${{inputs.apio_commit}}" >> "$GITHUB_ENV"
           echo "APIO_VERSION=${{inputs.apio_version}}" >> "$GITHUB_ENV"
-
-      # - name: Create date tag
-      #   run: |
-      #     date_tag="$(date +'%Y-%m-%d')"
-      #     echo "${date_tag}"
-      #     echo "DATE_TAG=${date_tag}" >> "$GITHUB_ENV"
 
 
       - name: Install python
@@ -95,13 +89,6 @@ jobs:
           cat -n $f
           sed -i.bak "/'usb':/d" "$f" && rm -f "${f}.bak"
           cat -n $f
-
-
-      # - name: Extract apio version
-      #   run: |
-      #     apio_version="$(pip show apio | grep Version: | cut -d ' ' -f2)"
-      #     echo ${apio_version}
-      #     echo "APIO_VERSION=${apio_version}" >> $GITHUB_ENV
 
 
       - name: Set up working directories
@@ -156,7 +143,7 @@ jobs:
         run: |
           # The github window bash doesn't have 'zip' so we use powershell instead.
           Push-Location _dist
-          $bundle = "apio-windows-amd64-${{env.APIO_VERSION}}-${{env.DATE_TAG}}-bundle.zip"
+          $bundle = "apio-windows-amd64-${{env.APIO_VERSION}}-${{env.APIO_TAG}}-bundle.zip"
           Compress-Archive -Path apio -DestinationPath ../${bundle}
           Pop-Location
           Get-ChildItem -Force
@@ -178,7 +165,7 @@ jobs:
       - name: Rename innosetup installer
         run: |
           ls -al
-          mv innosetup-installer.exe "apio-windows-amd64-${APIO_VERSION}-${DATE_TAG}-installer.exe"
+          mv innosetup-installer.exe "apio-windows-amd64-${APIO_VERSION}-${APIO_TAG}-installer.exe"
           ls -al
 
       - name: Export the pyinstaller bundle as an artifact
@@ -186,7 +173,7 @@ jobs:
         with:
           if-no-files-found: error
           name: "apio-windows-amd64-bundle"
-          path: "apio-windows-amd64-${{env.APIO_VERSION}}-${{env.DATE_TAG}}-bundle.zip"
+          path: "apio-windows-amd64-${{env.APIO_VERSION}}-${{env.APIO_TAG}}-bundle.zip"
 
 
       - name: Export the installer file as an artifact
@@ -194,4 +181,4 @@ jobs:
         with:
           if-no-files-found: error
           name: "apio-windows-amd64-installer"
-          path: "apio-windows-amd64-${{env.APIO_VERSION}}-${{env.DATE_TAG}}-installer.exe"
+          path: "apio-windows-amd64-${{env.APIO_VERSION}}-${{env.APIO_TAG}}-installer.exe"

--- a/.github/workflows/build-windows-amd64.yml
+++ b/.github/workflows/build-windows-amd64.yml
@@ -60,8 +60,8 @@ jobs:
       - name: Checkout the apio repo
         uses: actions/checkout@v4
         with:
-          # repository: FPGAwars/apio
-          repository: zapta/apio-dev
+          repository: FPGAwars/apio
+          # repository: zapta/apio-dev
           ref: develop
           path: apio-repo
 


### PR DESCRIPTION
The build parameters such as repo, commit, and release tag are now determined in the parent workflow build-all which passes them to the child workflows.