### PR TITLE
Change the invocation of innosetup to fix a broken build workflow.

### DIFF
--- a/.github/workflows/build-windows-amd64.yaml
+++ b/.github/workflows/build-windows-amd64.yaml
@@ -161,11 +161,11 @@ jobs:
           ls -al
           cat -n ${out}
 
+      # Build the windows installer.
       - name: Run innosetup
-        shell: cmd
-        run: |
-          "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" innosetup.iss
-          dir
+        uses: Minionguyjpro/Inno-Setup-Action@v1.2.7
+        with:
+            path: innosetup.iss
 
       - name: Rename innosetup installer
         run: |

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,7 @@
         "fpgas",
         "fpgawars",
         "freshclam",
+        "Minionguyjpro",
         "pkgbuild",
         "popd",
         "productbuild",


### PR DESCRIPTION
Change the way innosetup is invoked as a response to a recent github migration of windows latest from windows 2022 to 2025.
This fixes the broken build for Windows.